### PR TITLE
Remove some side effects and add an optional to save log to file as well.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,16 @@ that uses the standard Python logging module will play along nicely.
 Behaviours
 ----------
 
-- Messages are always written to stdout by default. A copy could be saved to
-  file by configuration.
+- Messages are always written to `stderr` if `glog` is used uninitialized.
+
+- By calling `glog.init(FILE_NAME)`, where FILE_NAME is a `str`, logs will be
+  saved to that file. Target files only need to be initialized once and could
+  be shared anywhere. Repeated initialization is supported, and all logs will
+  be added to that file only once.
+
+- Calling `glog.init("stderr")` or `glog.init("stdout")` will make glog log to
+  standard error or standard output.
+
 
 -  Lines are prefixed with a google-style log prefix, of the form
 

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,8 @@ that uses the standard Python logging module will play along nicely.
 Behaviours
 ----------
 
--  Messages are always written to stderr.
+-  Messages are always written to stderr by default. A copy could be saved to
+   file by configuration.
 
 -  Lines are prefixed with a google-style log prefix, of the form
 
@@ -75,6 +76,19 @@ parsing flags, like so:
         posargs = FLAGS(sys.argv)
         log.init()
         main(posargs[1:])
+
+To show log and save a copy to file at the same time:
+
+.. code:: python
+
+    import glog as log
+
+    log.init("example.log")
+
+    log.info("It works.")
+    log.warn("Something not ideal")
+    log.error("Something went wrong")
+    log.fatal("AAAAAAAAAAAAAAA!")
 
 Happy logging!
 

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ that uses the standard Python logging module will play along nicely.
 Behaviours
 ----------
 
--  Messages are always written to stderr by default. A copy could be saved to
-   file by configuration.
+- Messages are always written to stdout by default. A copy could be saved to
+  file by configuration.
 
 -  Lines are prefixed with a google-style log prefix, of the form
 

--- a/glog.py
+++ b/glog.py
@@ -112,10 +112,7 @@ class GlogFormatter(logging.Formatter):
         record.getMessage = lambda: record_message
         return logging.Formatter.format(self, record)
 
-logger = logging.getLogger()
-handler = logging.StreamHandler()
-
-level = logger.level
+logger = logging.getLogger("glog")
 
 
 def setLevel(newlevel):
@@ -124,24 +121,35 @@ def setLevel(newlevel):
     logger.debug('Log level set to %s', newlevel)
 
 
-def init():
+def init(filename=None):
+    logger.propagate = False
+    if filename is None:
+        handler = logging.StreamHandler()
+    else:
+        handler = logging.FileHandler(filename)
+
+    handler.setFormatter(GlogFormatter())
+    logger.addHandler(handler)
     setLevel(FLAGS.verbosity)
 
-debug = logging.debug
-info = logging.info
-warning = logging.warning
-warn = logging.warning
-error = logging.error
-exception = logging.exception
-fatal = logging.fatal
-log = logging.log
+debug = logger.debug
+info = logger.info
+warning = logger.warning
+warn = logger.warning
+error = logger.error
+exception = logger.exception
+fatal = logger.fatal
+log = logger.log
 
-DEBUG = logging.DEBUG
-INFO = logging.INFO
-WARNING = logging.WARNING
-WARN = logging.WARN
-ERROR = logging.ERROR
-FATAL = logging.FATAL
+
+DEBUG = logger.debug
+INFO = logger.info
+WARNING = logger.warning
+WARN = logger.warning
+ERROR = logger.error
+FATAL = logger.fatal
+
+# basicConfig = logger.basicConfig
 
 _level_names = {
     DEBUG: 'DEBUG',
@@ -166,6 +174,4 @@ GLOG_PREFIX_REGEX = (
     """) % ''.join(_level_letters)
 """Regex you can use to parse glog line prefixes."""
 
-handler.setFormatter(GlogFormatter())
-logger.addHandler(handler)
-setLevel(FLAGS.verbosity)
+init()

--- a/glog.py
+++ b/glog.py
@@ -142,12 +142,12 @@ fatal = logger.fatal
 log = logger.log
 
 
-DEBUG = logger.debug
-INFO = logger.info
-WARNING = logger.warning
-WARN = logger.warning
-ERROR = logger.error
-FATAL = logger.fatal
+DEBUG = logging.DEBUG
+INFO = logging.INFO
+WARNING = logging.WARNING
+WARN = logging.WARN
+ERROR = logging.ERROR
+FATAL = logging.FATAL
 
 # basicConfig = logger.basicConfig
 

--- a/glog.py
+++ b/glog.py
@@ -64,6 +64,7 @@ flags, like so:
 
 Happy logging!
 """
+import sys
 
 import logging
 import time
@@ -121,12 +122,17 @@ def setLevel(newlevel):
     logger.debug('Log level set to %s', newlevel)
 
 
-def init(filename=None):
+def init(destiny=None):
     logger.propagate = False
-    if filename is None:
+    destiny_type = type(destiny)
+    if destiny is None:
         handler = logging.StreamHandler()
+    elif destiny_type is file:
+        handler = logging.StreamHandler(destiny)
+    elif destiny_type is str:
+        handler = logging.FileHandler(destiny)
     else:
-        handler = logging.FileHandler(filename)
+        print("Cannot handle type {} destiny.".format(destiny_type))
 
     handler.setFormatter(GlogFormatter())
     logger.addHandler(handler)
@@ -174,4 +180,4 @@ GLOG_PREFIX_REGEX = (
     """) % ''.join(_level_letters)
 """Regex you can use to parse glog line prefixes."""
 
-init()
+init(sys.stdout)


### PR DESCRIPTION
Hi benley:

I found your code while trying to find a more permanent solution to logging. Nice work!

Just fix something and add something to make it better.
- While I was trying to get it to use, I found all logs are printed
  twice. After some debugging, I found this was due to the root logger gets two
  handlers since you add one more glog-style formatter handler. So if there are
  other libraries also add some handler to the root logger, which is my case,
  the log will be printed multiple times. To fix this, I use a standalone
  handler and set `logger.propagate = False`. So the side effects are
  removed.
- I also add some configuration to let people choose to save their log. The
  usage is updated in the README.
- The last commit is due to I am not sure what is the use of glog.INFO etc. Revert to the old code by this commit.

Shawn
Best
