### PR TITLE
Add --glog_capture_warnings flag

### DIFF
--- a/glog.py
+++ b/glog.py
@@ -104,6 +104,18 @@ handler.setFormatter(GlogFormatter())
 logger.addHandler(handler)
 
 
+class CaptureWarningsFlag(flags.BooleanFlag):
+    def __init__(self):
+        flags.BooleanFlag.__init__(self, 'glog_capture_warnings', True,
+                                   "Redirect warnings to log.warn messages")
+
+    def Parse(self, arg):
+        flags.BooleanFlag.Parse(self, arg)
+        logging.captureWarnings(self.value)
+
+flags.DEFINE_flag(CaptureWarningsFlag())
+
+
 class VerbosityParser(flags.ArgumentParser):
     """Sneakily use gflags parsing to get a simple callback."""
 


### PR DESCRIPTION
Useful for getting things like SSL warnings from urllib3 into nicely formatted log messages.

I can't decide: Should this flag default to True, or should it stay False to match the Python default?
